### PR TITLE
Require macros in cljs file

### DIFF
--- a/src/jx/reporter/karma.cljs
+++ b/src/jx/reporter/karma.cljs
@@ -1,5 +1,6 @@
 (ns jx.reporter.karma
-  (:require [cljs.test]))
+  (:require [cljs.test])
+  (:require-macros [jx.reporter.karma :as karma]))
 
 (def karma (volatile! nil))
 


### PR DESCRIPTION
This means that other users can use the macros without needing to call `:include-macros` true in their ns declaration.
