### PR TITLE
Adding fail message printing support

### DIFF
--- a/example_src/foo/bar_test.cljs
+++ b/example_src/foo/bar_test.cljs
@@ -7,4 +7,8 @@
 (deftest subtract-test
   (is (= (- 7 4) 3)))
 
+(deftest failing-test
+  (is (= 1 3))
+  (is (= 1 2) "One should be equal to two"))
+
 (defn not-a-test [])

--- a/example_src/foo/bar_test.cljs
+++ b/example_src/foo/bar_test.cljs
@@ -7,7 +7,8 @@
 (deftest subtract-test
   (is (= (- 7 4) 3)))
 
-(deftest failing-test
+;; Uncomment to see how failures are logged
+#_(deftest failing-test
   (is (= 1 3))
   (is (= 1 2) "One should be equal to two"))
 

--- a/src/jx/reporter/karma.cljs
+++ b/src/jx/reporter/karma.cljs
@@ -21,11 +21,13 @@
 (defn- now []
   (.getTime (js/Date.)))
 
-(defn- format-log [{:keys [expected actual] :as result}]
+(defn- format-log [{:keys [expected actual message] :as result}]
   (str
-    "Fail " (cljs.test/testing-vars-str result) "\n"
-    "Expected " (pr-str expected) "\n"
-    "Actual: " (pr-str actual) "\n"))
+    "Fail: " (cljs.test/testing-vars-str result) "\n"
+    "Expected: " (pr-str expected) "\n"
+    "Actual: " (pr-str actual) "\n"
+    (when message
+      (str "Message: " (pr-str message) "\n"))))
 
 (def test-var-result (volatile! []))
 


### PR DESCRIPTION
From [ClojureScript's test.clj](https://github.com/clojure/clojurescript/blob/master/src/main/cljs/cljs/test.clj):

``` clojure
(defmacro is
  "Generic assertion macro.  'form' is any predicate test.
  'msg' is an optional message to attach to the assertion.

  Example: (is (= 4 (+ 2 2)) \"Two plus two should be 4\")
  ..."
  ([form] `(cljs.test/is ~form nil))
  ([form msg]
   `(cljs.test/try-expr ~msg ~form)))
```

I wanted to print messages for certain failures, so I added support for it.

Thanks for the excellent library, keep up the good work.
