### PR TITLE
Cljs test output

### DIFF
--- a/example_src/foo/bar_test.cljs
+++ b/example_src/foo/bar_test.cljs
@@ -7,4 +7,9 @@
 (deftest subtract-test
   (is (= (- 7 4) 3)))
 
+;; Uncomment to see how failures are logged
+#_(deftest failing-test
+  (is (= 1 3))
+  (is (= 1 2) "One should be equal to two"))
+
 (defn not-a-test [])

--- a/src/jx/reporter/karma.cljs
+++ b/src/jx/reporter/karma.cljs
@@ -21,11 +21,13 @@
 (defn- now []
   (.getTime (js/Date.)))
 
-(defn- format-log [{:keys [expected actual] :as result}]
+(defn- format-log [{:keys [expected actual message] :as result}]
   (str
-    "Fail " (cljs.test/testing-vars-str result) "\n"
-    "Expected " (pr-str expected) "\n"
-    "Actual: " (pr-str actual) "\n"))
+    "Fail: " (cljs.test/testing-vars-str result) "\n"
+    "Expected: " (pr-str expected) "\n"
+    "Actual: " (pr-str actual) "\n"
+    (when message
+      (str "Message: " (pr-str message) "\n"))))
 
 (def test-var-result (volatile! []))
 

--- a/src/jx/reporter/karma.cljs
+++ b/src/jx/reporter/karma.cljs
@@ -23,11 +23,11 @@
 
 (defn- format-log [{:keys [expected actual message] :as result}]
   (str
-    "Fail: " (cljs.test/testing-vars-str result) "\n"
-    "Expected: " (pr-str expected) "\n"
-    "Actual: " (pr-str actual) "\n"
+    "FAIL in   " (cljs.test/testing-vars-str result) "\n"
+    "expected: " (pr-str expected) "\n"
+    "  actual: " (pr-str actual) "\n"
     (when message
-      (str "Message: " (pr-str message) "\n"))))
+      (str " message: " (pr-str message) "\n"))))
 
 (def test-var-result (volatile! []))
 


### PR DESCRIPTION
Updating format-log to produce a cljs.test-like output:

```
FAIL in   (some-test)
expected: (= :foo :bar)
  actual: (not (= :foo :bar))
 message: "Should be :foo"
```
