### PR TITLE
improving test failure message display

### DIFF
--- a/example_src/foo/bar_test.cljs
+++ b/example_src/foo/bar_test.cljs
@@ -10,6 +10,7 @@
 ;; Uncomment to see how failures are logged
 #_(deftest failing-test
   (is (= 1 3))
-  (is (= 1 2) "One should be equal to two"))
+  (is (= 1 2) "One should be equal to two")
+  (is (= 3 4) (str "Let me add in something\nfancy here: " {:a 1234})))
 
 (defn not-a-test [])

--- a/src/jx/reporter/karma.cljs
+++ b/src/jx/reporter/karma.cljs
@@ -27,7 +27,7 @@
     "expected: " (pr-str expected) "\n"
     "  actual: " (pr-str actual) "\n"
     (when message
-      (str " message: " (pr-str message) "\n"))))
+      (str " message: " message "\n"))))
 
 (def test-var-result (volatile! []))
 


### PR DESCRIPTION
Using `pr-str` when displaying the error message adds all sorts of goop like `\n`s to the output. As the message arg in an `(is ...)` form is usually a string, you probably don't need the `pr-str` around it. Sorry I didn't notice this earlier.
