### PR TITLE
adding run-all-tests macro with optional namespace regex

### DIFF
--- a/example_src/foo/test_runner.cljs
+++ b/example_src/foo/test_runner.cljs
@@ -1,8 +1,14 @@
 (ns foo.test-runner
-  (:require [jx.reporter.karma :refer-macros [run-tests]]
+  (:require [jx.reporter.karma :refer-macros [run-tests run-all-tests]]
             [foo.bar-test]))
 
 (enable-console-print!)
 
 (defn ^:export run [karma]
   (run-tests karma 'foo.bar-test))
+
+(defn ^:export run-all [karma]
+  (run-all-tests karma))
+
+(defn ^:export run-all-regex [karma]
+  (run-all-tests karma #".*-test$"))

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,6 +16,8 @@ module.exports = function (config) {
 
     client: {
       args: ['foo.test_runner.run']
+      // args: ['foo.test_runner.run_all']
+      // args: ['foo.test_runner.run_all_regex']
     },
 
 

--- a/src/jx/reporter/karma.clj
+++ b/src/jx/reporter/karma.clj
@@ -15,3 +15,15 @@
     `(cljs.test/run-tests ~@namespaces)
     `(do (jx.reporter.karma/start ~karma (tests-count ~@namespaces))
         (cljs.test/run-tests (cljs.test/empty-env ::karma) ~@namespaces))))
+
+(defmacro run-all-tests
+  ([karma] `(run-all-tests ~karma nil))
+  ([karma re]
+   (if (nil? karma)
+     `(cljs.test/run-all-tests ~re)
+     (let [namespaces# (map
+                         (fn [ns] `(quote ~ns))
+                         (cond->> (api/all-ns)
+                                  re (filter #(re-matches re (name %)))))]
+       `(do (jx.reporter.karma/start ~karma (tests-count ~@namespaces#))
+            (cljs.test/run-all-tests ~re (cljs.test/empty-env ::karma)))))))


### PR DESCRIPTION
I prefer not having to specify twice the list of test namespaces to execute so I snapped the code from cljs.test/run-all-tests to enumerate namespaces with an optional regex filter.
