### PR TITLE
Provide humane-test-output

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject karma-reporter "1.0.0"
+(defproject karma-reporter "1.0.1-SNAPSHOT"
 
   :description "A plugin for running clojurescript tests with Karma."
 

--- a/src/jx/reporter/karma.cljs
+++ b/src/jx/reporter/karma.cljs
@@ -1,5 +1,6 @@
 (ns jx.reporter.karma
-  (:require [cljs.test])
+  (:require [cljs.test]
+            [cljs.pprint :as pp])
   (:require-macros [jx.reporter.karma :as karma]))
 
 (def karma (volatile! nil))
@@ -22,12 +23,13 @@
   (.getTime (js/Date.)))
 
 (defn- format-log [{:keys [expected actual message] :as result}]
-  (str
-    "FAIL in   " (cljs.test/testing-vars-str result) "\n"
-    "expected: " (pr-str expected) "\n"
-    "  actual: " (pr-str actual) "\n"
+  (with-out-str
+    (println "FAIL in  " (cljs.test/testing-vars-str result))
+    (binding [*out* (pp/get-pretty-writer *out*)]
+      (print "expected: ") (pp/pprint expected)
+      (print "  actual: ") (pp/pprint actual))
     (when message
-      (str " message: " message "\n"))))
+      (println " message: " message "\n"))))
 
 (def test-var-result (volatile! []))
 


### PR DESCRIPTION
This is a clone of humane-test-output's formatting code, translated to
ClojureScript.

This isn't ready to merge, it still has
- [ ] Align vertical columns for pretty printed output.
- [ ] Diff equality output
