### PR TITLE
Karma-coverage plugin support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject karma-reporter "2.0.1"
+(defproject karma-reporter "2.0.2"
 
   :description "A plugin for running clojurescript tests with Karma."
 

--- a/src/jx/reporter/karma.cljs
+++ b/src/jx/reporter/karma.cljs
@@ -16,9 +16,25 @@
   (when (karma?)
     (.result @karma (clj->js m))))
 
+(defn- coverage-result
+  []
+  (let [xform
+        (comp
+          (map (partial re-find #"__cov_[^_]+$"))
+          (filter (comp not nil?))
+          (map (partial aget js/window))
+          (mapcat (juxt #(.-path %) identity))
+          (partition-all 2)
+          )
+        all-vars (.keys js/Object js/window)
+        cov-info (into {} xform all-vars)
+        ]
+    (clj->js {:coverage cov-info})
+    ))
+
 (defn- karma-complete! []
   (when (karma?)
-    (.complete @karma #js {})))
+    (.complete @karma (coverage-result))))
 
 (defn- now []
   (.getTime (js/Date.)))


### PR DESCRIPTION
When we run with karma-coverage module we wand to pass gathered istanbul coverage within karma complete method so that people will have at least coverage for compiled JS file.