### PR TITLE
Derive karma reporter from default reporter

### DIFF
--- a/src/jx/reporter/karma.cljs
+++ b/src/jx/reporter/karma.cljs
@@ -35,6 +35,15 @@
 
 (defmethod cljs.test/report :karma [_])
 
+;; By default, all report types for :cljs.test reporter are printed
+(derive ::karma :cljs.test/default)
+
+;; Do not print "Ran <t> tests containing <a> assertions."
+(defmethod cljs.test/report [::karma :summary] [_])
+
+;; Do not print "Testing <ns>"
+(defmethod cljs.test/report [::karma :begin-test-ns] [m])
+
 (defmethod cljs.test/report [::karma :begin-test-var] [_]
   (vreset! test-var-time-start (now))
   (vreset! test-var-result []))


### PR DESCRIPTION
Fixes https://github.com/honzabrecka/karma-reporter/issues/11

Previously, if another package added a report type to the default
reporter, karma-reporter would not display it by default. Now,
the behavior is the opposite - any new report types will be
run by default, and the user can implement the multimethod if they
wish to hide the report.

Test process:

1. Created `example_src/karma.conf.js`
```js
module.exports = function(config) {
    var root = '../target/public/test'// same as :output-dir

    config.set({
        frameworks: ['cljs-test'],

        files: [
            root + '/goog/base.js',
            root + '/cljs_deps.js',
            root + '/foo.js',// same as :output-to
            {pattern: root + '/*.js', included: false},
            {pattern: root + '/**/*.js', included: false}
        ],

        client: {
            // main function
            args: ['foo.test_runner.run']
        },

        // singleRun set to false does not work!
        singleRun: true,

        browsers: ['Chrome']
    })
}
```
2. Built tests `lein cljsbuild auto test`
3. Run karma `npm install karma-cljs-test karma karma-chrome-launcher --save-dev`
4. Save output
5. Make changes in this PR
6. Run karma again
7. Confirm output is the same (with the exception of date and time information, which of course changes between runs)
8. Added dummy report to default reporter
```clojure
(defmethod cljs.test/report [:cljs.test/default :foobar] [_]
  (prn "fooo bar !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"))
```
9. Called `(cljs.test/report {:type :foobar})` from bar_test.cljs
10. Confirmed that new report was printed by default

